### PR TITLE
updated linters to support GO version 1.18+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 2
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
       - name: Run linter
         run: make ci-lint
       - name: Run tests

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 ci-lint: install-linter lint
 
 install-linter:
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 run:
 	@go run ./... fuzz


### PR DESCRIPTION
Errors that the linter now finds:
```bash
Error: irprint/irprint.go:189:3: ifElseChain: rewrite if-else to switch statement (gocritic)
make: *** [Makefile:13: lint] Error 1
		if v == 0 {
		^

Error: irgen/value_generator.go:88:1: receiver-naming: receiver name b should be consistent with previous receiver name g for valueGenerator (revive)
func (b *valueGenerator) BoolValue() bool {
	return randutil.Chance(b.rand, 0.5)
}
Error: Process completed with exit code 2.
```

For the purposes of this PR, I did not correct the errors I found :)